### PR TITLE
Fix conflicts with Feature/activity #6

### DIFF
--- a/pkg/activity/activity_test.go
+++ b/pkg/activity/activity_test.go
@@ -2,8 +2,6 @@ package activity_test
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -170,61 +168,56 @@ func TestCancelP(t *testing.T) {
 	}
 }
 
-// testcase 1. whether applyC works -> Done
-// testcase 2. ErrNotInParticipants -> Done
-// testcase 3. ErrBeingProcessed -> Done
 func TestApplyC(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(config.MongoURI))
 	if err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	testCollection := client.Database("club").Collection("activities")
 
-	// testcase 1
+	// testcase 1. whether applyC works -> Done
 	targetActivity := activity.New(1, 1, "Place", "MT", "Testing", []string{"ApplyC"}, false)
 
-	// testcase 2
-	// targetActivity := activity.New(1, 1, "Place", "MT", "Testing", []string{}, false)
+	// testcase 2. ErrNotParticipant -> Done
+	// testcase 3. ErrBeingProcessed -> Done
 
 	// Initialize Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	// insert test activity
 	if _, err := testCollection.InsertOne(ctx, targetActivity); err != nil {
-		log.Println("INSERT_ERR")
-		log.Fatal(err)
+		t.Log("INSERT_ERR")
+		t.Error(err)
 	}
 
 	if err = activity.ApplyC(targetActivity.ID, "ApplyC"); err != nil {
-		log.Println("APPLYC_ERR")
-		log.Fatalln(err)
+		t.Log("APPLYC_ERR")
+		t.Error(err)
 	}
 
 	// Reset Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := client.Disconnect(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 }
 
-// testcase 1. whether CancelC works
-// testcase 2. ErrNoMember
 func TestCancelC(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(config.MongoURI))
 	if err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	testCollection := client.Database("club").Collection("activities")
@@ -232,28 +225,30 @@ func TestCancelC(t *testing.T) {
 
 	// insert test activity
 	if _, err := testCollection.InsertOne(ctx, targetActivity); err != nil {
-		log.Println("INSERT_ERR")
-		log.Fatal(err)
+		t.Log("INSERT_ERR")
+		t.Error(err)
 	}
 
 	if err = activity.ApplyC(targetActivity.ID, "ApplyC"); err != nil {
-		log.Println("APPLYC_ERR")
-		log.Println(targetActivity.ID)
-		log.Fatalln(err)
+		t.Log("APPLYC_ERR")
+		t.Log(targetActivity.ID)
+		t.Error(err)
 	}
 
+	// testcase 1. whether CancelC works
+	// testcase 2. ErrNotMember
 	if err = activity.CancelC(targetActivity.ID, "ApplyC"); err != nil {
-		log.Println("CANCELC_ERR")
-		log.Fatalln(err)
+		t.Log("CANCELC_ERR")
+		t.Error(err)
 	}
 
 	// Reset Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := client.Disconnect(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -263,7 +258,7 @@ func TestCapplies(t *testing.T) {
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(config.MongoURI))
 	if err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	testCollection := client.Database("club").Collection("activities")
@@ -271,22 +266,21 @@ func TestCapplies(t *testing.T) {
 
 	// insert test activity
 	if _, err := testCollection.InsertOne(ctx, targetActivity); err != nil {
-		log.Println("INSERT_ERR")
-		log.Fatal(err)
+		t.Log("INSERT_ERR")
+		t.Error(err)
 	}
 
-	res, err := activity.Capplies(targetActivity.ID)
-	if err != nil {
-		log.Fatal(err)
+	if _, err := activity.Capplies(targetActivity.ID); err != nil {
+		t.Error(err)
 	}
-	fmt.Println(res)
+
 	// Reset Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := client.Disconnect(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -296,7 +290,7 @@ func TestApproveC(t *testing.T) {
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(config.MongoURI))
 	if err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	testCollection := client.Database("club").Collection("activities")
@@ -304,27 +298,27 @@ func TestApproveC(t *testing.T) {
 
 	// insert test activity
 	if _, err := testCollection.InsertOne(ctx, targetActivity); err != nil {
-		log.Println("INSERT_ERR")
-		log.Fatal(err)
+		t.Log("INSERT_ERR")
+		t.Error(err)
 	}
 
 	// set cancelers
 	if err = activity.ApplyC(targetActivity.ID, "Succeed!"); err != nil {
-		log.Println("APPLYC_ERR")
-		log.Fatalln(err)
+		t.Log("APPLYC_ERR")
+		t.Error(err)
 	}
 
 	if err = activity.ApproveC(targetActivity.ID, "Succeed!"); err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	// Reset Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := client.Disconnect(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -334,7 +328,7 @@ func TestRejectC(t *testing.T) {
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(config.MongoURI))
 	if err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	testCollection := client.Database("club").Collection("activities")
@@ -342,27 +336,26 @@ func TestRejectC(t *testing.T) {
 
 	// insert test activity
 	if _, err := testCollection.InsertOne(ctx, targetActivity); err != nil {
-		log.Println("INSERT_ERR")
-		log.Fatal(err)
+		t.Log("INSERT_ERR")
+		t.Error(err)
 	}
 
 	// set cancelers
 	if err = activity.ApplyC(targetActivity.ID, "Succeed!"); err != nil {
-		log.Println("APPLYC_ERR")
-		log.Fatalln(err)
+		t.Log("APPLYC_ERR")
+		t.Error(err)
 	}
 
 	if err = activity.RejectC(targetActivity.ID, "Succeed!"); err != nil {
-		log.Fatalln(err)
+		t.Error(err)
 	}
 
 	// Reset Collection
 	if err := testCollection.Drop(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := client.Disconnect(ctx); err != nil {
-		log.Fatal(err)
+		t.Error(err)
 	}
-
 }

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -3,6 +3,7 @@ package member
 
 import "time"
 
+// Member represents a club member state.
 type Member struct {
 	ID         string `json:"id" bson:"id"`                 // student ID
 	Password   string `json:"password" bson:"password"`     // password
@@ -17,6 +18,8 @@ type Member struct {
 	CreatedAt  int64  `json:"created_at" bson:"created_at"` // when created - Unix timestamp
 	UpdatedAt  int64  `json:"updated_at" bson:"updated_at"` // last updated - Unix timestamp
 }
+
+type Members []Member
 
 // New returns a new club member.
 func New(id string, name string, department string, grade string, phone string, email string, attendance int) *Member {
@@ -35,3 +38,4 @@ func New(id string, name string, department string, grade string, phone string, 
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}
+}

--- a/web/api/v1/activity/handlers.go
+++ b/web/api/v1/activity/handlers.go
@@ -1,5 +1,2 @@
-// Package middleware defines the router layer of the Buddy System.
-package middleware
-
-// TODO
-// Define the extension point of the API server
+// Package activity defines the router layer of the club activity of the Buddy System.
+package activity


### PR DESCRIPTION
Fixed conflicts and comments, Added some useful type aliases for `package activity`

@Abrahamkwon
Could you check if there is no documents in `activities` collection, the tests fail with `mongo.ErrNoDocuments`?
I mentioned it on Slack.